### PR TITLE
Shallow renaming of Oragono to Ergo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-oragono-ldap
-============
+ergo-ldap
+=========
 
-This is an authentication plugin for Oragono that defers password checking to an LDAP server.
+This is an authentication plugin for Ergo that defers password checking to an LDAP server.
 
 To build the plugin, [install Go 1.14 or higher](https://golang.org/dl), then run `make`; this will build an `oragono-ldap` binary.
 


### PR DESCRIPTION
Not changing any code or binary name so it's not an issue,
but mentioning "Oragono" in the documentation may be confusing.